### PR TITLE
Normalize strict OpenAI tool schemas

### DIFF
--- a/Sources/OpenAIKit/Tools/Tool.swift
+++ b/Sources/OpenAIKit/Tools/Tool.swift
@@ -75,12 +75,7 @@ extension Toolable {
       fatalError("Boolean schemas are not supported at root level for tools")
     }
 
-    var parameters = rawParameters
-    // OpenAI tool validation now expects object schemas to include an explicit
-    // `properties` key, even when a tool takes zero arguments.
-    if parameters["type"] == .string("object"), parameters["properties"] == nil {
-      parameters["properties"] = .object([:])
-    }
+    let parameters = Self.normalizeToolSchemaObject(rawParameters, strict: strict)
 
     return FunctionTool(
       name: name,
@@ -94,5 +89,93 @@ extension Toolable {
 
   public func toTool() -> OpenAICore.Tool {
     .function(toFunctionTool())
+  }
+
+  private static func normalizeToolSchemaObject(
+    _ schemaObject: [KeywordIdentifier: JSONValue],
+    strict: Bool
+  ) -> [KeywordIdentifier: JSONValue] {
+    var normalized = schemaObject.mapValues {
+      normalizeToolSchemaValue($0, strict: strict)
+    }
+
+    normalized = collapseNullableCompositions(in: normalized)
+
+    if normalized["type"] == .string("object"), normalized["properties"] == nil {
+      normalized["properties"] = .object([:])
+    }
+
+    if strict, normalized["type"] == .string("object"), normalized["additionalProperties"] == nil {
+      normalized["additionalProperties"] = .boolean(false)
+    }
+
+    if strict,
+      normalized["type"] == .string("object"),
+      let properties = normalized["properties"]?.object
+    {
+      let requiredKeys =
+        (normalized["required"]?.array?.compactMap(\.string) ?? []) + properties.keys
+      let deduplicated = Array(Set(requiredKeys)).sorted().map(JSONValue.string)
+      normalized["required"] = .array(deduplicated)
+    }
+
+    return normalized
+  }
+
+  private static func normalizeToolSchemaValue(
+    _ value: JSONValue,
+    strict: Bool
+  ) -> JSONValue {
+    switch value {
+    case .object(let object):
+      return .object(normalizeToolSchemaObject(object, strict: strict))
+    case .array(let array):
+      return .array(array.map { normalizeToolSchemaValue($0, strict: strict) })
+    default:
+      return value
+    }
+  }
+
+  private static func collapseNullableCompositions(
+    in schemaObject: [KeywordIdentifier: JSONValue]
+  ) -> [KeywordIdentifier: JSONValue] {
+    for keyword in ["oneOf", "anyOf"] {
+      guard let composition = schemaObject[keyword]?.array else { continue }
+
+      let nonNullBranches = composition.filter { !isNullSchema($0) }
+      guard nonNullBranches.count == 1, case .object(let branchObject) = nonNullBranches[0] else {
+        continue
+      }
+
+      var collapsed = schemaObject
+      collapsed.removeValue(forKey: keyword)
+      var nullableBranch = branchObject
+      nullableBranch["type"] = appendNullType(to: branchObject["type"])
+      collapsed.merge(nullableBranch) { current, _ in current }
+      return collapsed
+    }
+
+    return schemaObject
+  }
+
+  private static func isNullSchema(_ value: JSONValue) -> Bool {
+    guard case .object(let object) = value else { return false }
+    return object["type"] == .string("null")
+  }
+
+  private static func appendNullType(to value: JSONValue?) -> JSONValue? {
+    guard let value else { return nil }
+
+    switch value {
+    case .string(let string):
+      return .array([.string(string), .string("null")])
+    case .array(let values):
+      if values.contains(.string("null")) {
+        return .array(values)
+      }
+      return .array(values + [.string("null")])
+    default:
+      return value
+    }
   }
 }

--- a/Tests/OpenAIKitTests/FunctionToolSerializationTests.swift
+++ b/Tests/OpenAIKitTests/FunctionToolSerializationTests.swift
@@ -60,6 +60,23 @@ struct FunctionToolSerializationTests {
     #expect(properties != nil)
     #expect(properties?.isEmpty == true)
   }
+
+  @Test("Strict Toolable schemas normalize nullable unions and set additionalProperties false recursively")
+  func strictToolableSchemaNormalizesNullableUnions() {
+    let tool = StrictNestedArgumentsTool().toFunctionTool().toOpenAPI()
+    let schema = tool.parameters?.value
+    let rootAdditionalProperties = schema?["additionalProperties"] as? Bool
+    let rootRequired = schema?["required"] as? [String]
+    let groundings = ((schema?["properties"] as? [String: Any])?["groundings"] as? [String: Any])
+    let groundingItems = groundings?["items"] as? [String: Any]
+    let groundingAdditionalProperties = groundingItems?["additionalProperties"] as? Bool
+    let groundingOneOf = groundings?["oneOf"] as? [Any]
+
+    #expect(rootAdditionalProperties == false)
+    #expect(rootRequired?.sorted() == ["groundings", "prompt"])
+    #expect(groundingAdditionalProperties == false)
+    #expect(groundingOneOf == nil)
+  }
 }
 
 private struct NoArgumentsTool: Toolable {
@@ -75,5 +92,53 @@ private struct NoArgumentsTool: Toolable {
 
   func call(parameters _: Void) async throws -> String {
     "[]"
+  }
+}
+
+private struct StrictNestedArgumentsTool: Toolable {
+  struct Parameters: Codable, Sendable {
+    let prompt: String
+    let groundings: [Grounding]?
+
+    struct Grounding: Codable, Sendable {
+      let type: String
+      let id: String
+    }
+  }
+
+  let name = "generate-grok-image"
+  let description: String? = "Generate an image."
+  let strict = true
+
+  var parameters: some JSONSchemaComponent<Parameters> {
+    JSONObject {
+      JSONProperty(key: "prompt") {
+        JSONString()
+      }
+      .required()
+
+      JSONProperty(key: "groundings") {
+        JSONArray {
+          JSONObject {
+            JSONProperty(key: "type") {
+              JSONString()
+            }
+            .required()
+
+            JSONProperty(key: "id") {
+              JSONString()
+            }
+            .required()
+          }
+          .map { Parameters.Grounding(type: $0.0, id: $0.1) }
+        }
+      }
+      .required()
+    }
+    .map { Parameters(prompt: $0.0, groundings: $0.1) }
+  }
+
+  func call(parameters _: Parameters) async throws -> String {
+    "{}"
   }
 }


### PR DESCRIPTION
## Summary
- normalize strict function tool schemas for OpenAI responses
- add missing `additionalProperties: false` to strict object nodes
- flatten nullable composition forms that OpenAI rejects
- synthesize full `required` arrays for strict object schemas

## Testing
- swift test --filter FunctionToolSerializationTests